### PR TITLE
split clean() into two targets: clean_db() and clean_config_files()

### DIFF
--- a/scripts/setupTranSMARTDevelopment.gant
+++ b/scripts/setupTranSMARTDevelopment.gant
@@ -278,7 +278,7 @@ target(clean_db: "clean out the database...")
     }
 }
 
-target(clean_config_files: "clean out the config files...)
+target(clean_config_files: "clean out the config files...")
 {
     //remove <user_home>/.grails/transmartConfig files:
     delete(dir: transmartuser_home | ".grails/transmartConfig")

--- a/scripts/setupTranSMARTDevelopment.gant
+++ b/scripts/setupTranSMARTDevelopment.gant
@@ -257,6 +257,12 @@ target(cleanBuildDir: 'delete build dir contents')
 
 target(clean: "clean-up to run again...")
 {
+	clean_db()
+	clean_config_files()
+}
+
+target(clean_db: "clean out the database...")
+{
     //drop postgres "transmart" db:
     def command =  "drop database if exists $transmart_db_name"
     dbCommand(command, failOnError: true)
@@ -270,7 +276,10 @@ target(clean: "clean-up to run again...")
     roles.each {
         dbCommand("drop role $it", failOnError: false, quiet: true)
     }
+}
 
+target(clean_config_files: "clean out the config files...)
+{
     //remove <user_home>/.grails/transmartConfig files:
     delete(dir: transmartuser_home | ".grails/transmartConfig")
 }


### PR DESCRIPTION
split clean() into two targets: clean_db() and clean_config_files(); So that I can run the delete of the database separately from the delete of the config files.
